### PR TITLE
feat: add overload protection to the readiness and liveness endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Example Usage:
 
 
 This will add 2 `GET` endpoints `/api/health/liveness` and `/api/health/readiness`
-that will return a `200 OK` response.
+that will return a `200 OK` response. This module uses `overload-protection` to identify
+when a process may be overloaded, and will return `HTTP 503 Service Unavailable`
+if the service becomes too heavily loaded. Configuration of the `protection-config` module
+may be passed as `options.protectionConfig`.
+
+See: https://github.com/davidmarkclements/overload-protection/
 
 #### Parameters
 
@@ -26,3 +31,4 @@ that will return a `200 OK` response.
 * options.livenessURLURL - string - url where the livenessURL probe is located
 * options.readinessCallback - function - function to call when the readiness probe is triggered
 * options.livenessCallback - function - function to call when the liveness probe is triggered
+* options.protectionConfig - object - options passed direction to `overload-protection`

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const protection = require('overload-protection');
+
 const READINESS_URL = '/api/health/readiness';
 const LIVENESS_URL = '/api/health/liveness';
 
@@ -14,8 +16,18 @@ function defaultResponse (request, response) {
   @param {string} [options.livenessURL] - url where the liveness probe is located
   @param {function} [options.readinessCallback] - function to call when the readiness probe is triggered
   @param {function} [options.livenessCallback] - function to call when the liveness probe is triggered
+  @param {object} [options.protectionConfig] - options passed directly to 'overload-protection' module
 */
 module.exports = function (app, options = {}) {
-  app.use(options.readinessURL || READINESS_URL, options.readinessCallback || defaultResponse);
-  app.use(options.livenessURL || LIVENESS_URL, options.livenessCallback || defaultResponse);
+  const protectCfg = {
+    production: process.env.NODE_ENV === 'production',
+    maxHeapUsedBytes: 0, // maximum heap used threshold (0 to disable) [default 0]
+    maxRssBytes: 0 // maximum rss size threshold (0 to disable) [default 0]
+  };
+  const readiness = options.readinessURL || READINESS_URL;
+  const liveness = options.livenessURL || LIVENESS_URL;
+  app.use(readiness, protection('http', protectCfg));
+  app.use(readiness, options.readinessCallback || defaultResponse);
+  app.use(liveness, options.livenessCallback || defaultResponse);
+  app.use(liveness, protection('http', protectCfg));
 };

--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ function defaultResponse (request, response) {
   @param {object} [options.protectionConfig] - options passed directly to 'overload-protection' module
 */
 module.exports = function (app, options = {}) {
-  const protectCfg = {
+  const protectCfg = Object.assign({
     production: process.env.NODE_ENV === 'production',
     maxHeapUsedBytes: 0, // maximum heap used threshold (0 to disable) [default 0]
     maxRssBytes: 0 // maximum rss size threshold (0 to disable) [default 0]
-  };
+  }, options.protectionConfig);
   const readiness = options.readinessURL || READINESS_URL;
   const liveness = options.livenessURL || LIVENESS_URL;
   const protect = protection('http', protectCfg);

--- a/index.js
+++ b/index.js
@@ -26,8 +26,10 @@ module.exports = function (app, options = {}) {
   };
   const readiness = options.readinessURL || READINESS_URL;
   const liveness = options.livenessURL || LIVENESS_URL;
-  app.use(readiness, protection('http', protectCfg));
+  const protect = protection('http', protectCfg);
+
+  app.use(readiness, protect);
   app.use(readiness, options.readinessCallback || defaultResponse);
   app.use(liveness, options.livenessCallback || defaultResponse);
-  app.use(liveness, protection('http', protectCfg));
+  app.use(liveness, protect);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2300,6 +2300,14 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
+    "loopbench": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/loopbench/-/loopbench-1.2.0.tgz",
+      "integrity": "sha1-dgG3P1cJfHP0JqBev3gat+pJF/8=",
+      "requires": {
+        "xtend": "4.0.1"
+      }
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -4331,6 +4339,14 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "overload-protection": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/overload-protection/-/overload-protection-1.1.0.tgz",
+      "integrity": "sha512-hgpWyJb7EQL4531wAa9eCbaEI326LnKHgtJH9Q88DeQ4tsXjyZZaqlrFCVCAfZ7rR4SVsS06SZxEHmxL/dHpnw==",
+      "requires": {
+        "loopbench": "1.2.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -5523,8 +5539,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "szero": "^1.0.0",
     "tap-spec": "~4.1.1",
     "tape": "~4.8.0"
+  },
+  "dependencies": {
+    "overload-protection": "~1.1.0"
   }
 }


### PR DESCRIPTION
See: https://github.com/davidmarkclements/overload-protection

The protection is only added for the two endpoints that we define,
however it's generally used as a middleware for all requests.
We could make this an option.