### PR TITLE
fix: response should include content type header

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const READINESS_URL = '/api/health/readiness';
 const LIVENESS_URL = '/api/health/liveness';
 
 function defaultResponse (request, response) {
+  response.setHeader('Content-Type', 'text/html');
   return response.end('OK');
 }
 

--- a/test/kube-probe-test.js
+++ b/test/kube-probe-test.js
@@ -99,3 +99,22 @@ test('default content type for liveness endpoint', t => {
       t.end();
     });
 });
+
+test('custom content type for liveness endpoint', t => {
+  t.plan(1);
+  const app = connect();
+  probe(app, {
+    livenessCallback: (request, response) => {
+      response.setHeader('Content-Type', 'application/json');
+      response.end(JSON.stringify({status: 'OK'}));
+    }
+  });
+  supertest(app)
+    .get('/api/health/liveness')
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .then(response => {
+      t.strictEqual(response.body.status, 'OK', 'expected response');
+      t.end();
+    });
+});

--- a/test/kube-probe-test.js
+++ b/test/kube-probe-test.js
@@ -71,3 +71,31 @@ test('test different url and callback for liveness', (t) => {
       t.end();
     });
 });
+
+test('default content type for readiness endpoint', t => {
+  t.plan(1);
+  const app = connect();
+  probe(app);
+  supertest(app)
+    .get('/api/health/readiness')
+    .expect(200)
+    .expect('Content-Type', /text\/html/)
+    .then(response => {
+      t.strictEqual(response.text, 'OK', 'expected response');
+      t.end();
+    });
+});
+
+test('default content type for liveness endpoint', t => {
+  t.plan(1);
+  const app = connect();
+  probe(app);
+  supertest(app)
+    .get('/api/health/liveness')
+    .expect(200)
+    .expect('Content-Type', /text\/html/)
+    .then(response => {
+      t.strictEqual(response.text, 'OK', 'expected response');
+      t.end();
+    });
+});


### PR DESCRIPTION
Previously, the plugin relied on Express.js to set the `Content-Type` header. But now that we are trying to support all connect.js frameworks, we need to set this explicitly. 