### PR TITLE
enahance: allow overload protection to be disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,14 +23,17 @@ module.exports = function (app, options = {}) {
   const protectCfg = Object.assign({
     production: process.env.NODE_ENV === 'production',
     maxHeapUsedBytes: 0, // maximum heap used threshold (0 to disable) [default 0]
-    maxRssBytes: 0 // maximum rss size threshold (0 to disable) [default 0]
+    maxRssBytes: 0, // maximum rss size threshold (0 to disable) [default 0]
+    enabled: true // user can set 'enabled' to false to turn this off
   }, options.protectionConfig);
   const readiness = options.readinessURL || READINESS_URL;
   const liveness = options.livenessURL || LIVENESS_URL;
   const protect = protection('http', protectCfg);
 
-  app.use(readiness, protect);
+  if (protectCfg.enabled === true) {
+    app.use(readiness, protect);
+    app.use(liveness, protect);
+  }
   app.use(readiness, options.readinessCallback || defaultResponse);
   app.use(liveness, options.livenessCallback || defaultResponse);
-  app.use(liveness, protect);
 };

--- a/test/kube-probe-test.js
+++ b/test/kube-probe-test.js
@@ -118,3 +118,22 @@ test('custom content type for liveness endpoint', t => {
       t.end();
     });
 });
+
+test('custom content type for liveness endpoint', t => {
+  t.plan(1);
+  const app = connect();
+  probe(app, {
+    livenessCallback: (request, response) => {
+      response.setHeader('Content-Type', 'application/json');
+      response.end(JSON.stringify({status: 'OK'}));
+    }
+  });
+  supertest(app)
+    .get('/api/health/liveness')
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .then(response => {
+      t.strictEqual(response.body.status, 'OK', 'expected response');
+      t.end();
+    });
+});


### PR DESCRIPTION
This allows for use with hapi, with a little chewing gum and baling wire.

```js
const kubeProbe = require('kube-probe');
const server = ... // init hapi server

const probe = {
  name: 'kube-probe',
  version: '1.0.0',
  register: function (server, options) {
    server.use = (route, handler) => {
      server.route({
        path: route,
        method: 'GET',
        handler
      })
    }
    // don't enable overload protection
    // hapi isn't happy about that
    kubeProbe(server, {
      protectionConfig: {
        enabled: false
      }});
  }
};

await server.register(probe);

```