### PR TITLE
Use the nodeshift/node-runtimes orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,45 +4,34 @@
 #
 version: 2.1
 
-commands:
-  test-nodejs:
-    steps:
-      - run:
-          name: 'Output Node Version'
-          command: 'node -v'
-
-      - checkout
-
-      # install with npm ci to make sure package.json and lock are N'Sync
-      # No need to cache node_modules since npm ci will delete it
-      - run: npm ci
-
-      # run tests!
-      - run: npm run ci
-
-jobs:
-  node10:
-    docker:
-      - image: circleci/node:10
-    steps:
-      - test-nodejs
-
-  node12:
-    docker:
-      - image: circleci/node:12
-    steps:
-      - test-nodejs
+orbs:
+  node_matrix: nodeshift/node-runtimes@0.0.1
 
 workflows:
   version: 2
   test_node_versions:
     jobs:
-      - node10:
+      - node_matrix/node10:
         filters:
           branches:
             ignore:
               - gh-pages
-      - node12:
+      - node_matrix/node10-ubi8-redhat:
+        filters:
+          branches:
+            ignore:
+              - gh-pages
+      - node_matrix/node12:
+        filters:
+          branches:
+            ignore:
+              - gh-pages
+      - node_matrix/node12-ubi8-redhat:
+        filters:
+          branches:
+            ignore:
+              - gh-pages
+      - node_matrix/node14:
         filters:
           branches:
             ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,28 +11,8 @@ workflows:
   version: 2
   test_node_versions:
     jobs:
-      - node_matrix/node10:
-        filters:
-          branches:
-            ignore:
-              - gh-pages
-      - node_matrix/node10-ubi8-redhat:
-        filters:
-          branches:
-            ignore:
-              - gh-pages
-      - node_matrix/node12:
-        filters:
-          branches:
-            ignore:
-              - gh-pages
-      - node_matrix/node12-ubi8-redhat:
-        filters:
-          branches:
-            ignore:
-              - gh-pages
-      - node_matrix/node14:
-        filters:
-          branches:
-            ignore:
-              - gh-pages
+      - node_matrix/node10
+      - node_matrix/node10-ubi8-redhat
+      - node_matrix/node12
+      - node_matrix/node12-ubi8-redhat
+      - node_matrix/node14


### PR DESCRIPTION
This adds the nodeshift/node-runtimes orb to the circleci config.

it also removes the filtering of gh-pages, which wasn't being used anyway